### PR TITLE
fix: 온리유희왕 가격 파싱 오류 수정

### DIFF
--- a/src/utils/crawler.js
+++ b/src/utils/crawler.js
@@ -83,17 +83,21 @@ function extractCardCode(title) {
 /**
  * 상품 상태(신품/중고)를 파싱합니다.
  * @param {string} title - 상품 제목
- * @returns {string} - 파싱된 상품 상태 (A급, B급, C급, 신품)
+ * @returns {string} - 파싱된 상품 상태 (S급, A급, B급, C급, 신품)
  */
 function parseCondition(title) {
-  // 중고 등급 확인
-  if (/\[A급\]|\(A급\)|A급|A\+|A등급|A품/i.test(title)) {
+
+  if (/\[S급\]|\(S급\)|S급|S\+|S등급|S-급/i.test(title)) {
+    return 'S급';
+  }
+  
+  if (/\[A급\]|\(A급\)|A급|A\+|A등급/i.test(title)) {
     return 'A급';
   }
-  if (/\[B급\]|\(B급\)|B급|B등급|B품/i.test(title)) {
+  if (/\[B급\]|\(B급\)|B급|B등급/i.test(title)) {
     return 'B급';
   }
-  if (/\[C급\]|\(C급\)|C급|C등급|C품/i.test(title)) {
+  if (/\[C급\]|\(C급\)|C급|C등급/i.test(title)) {
     return 'C급';
   }
   

--- a/src/utils/rarityUtil.js
+++ b/src/utils/rarityUtil.js
@@ -14,7 +14,7 @@ function parseRarity(title) {
   const rarityPatterns = [
     { pattern: /(엑스트라\s*시크릿\s*레어|엑스트라시크릿레어|엑시크|extra\s*secret\s*rare)/i, rarity: '엑스트라 시크릿 레어', code: 'EXSE' },
     { pattern: /(20th\s*시크릿\s*레어|20시크릿\s*레어|20th\s*secret\s*rare|twentieth\s*secret\s*rare)/i, rarity: '20th 시크릿 레어', code: '20th SE' },
-    { pattern: /(QC\s*시크릿\s*레어|쿼터\s*센츄리\s*시크|QC\s*쿼터\s*시크릿\s*레어|QC시크릿레어|쿼터\s*시크릿|쿼터\s*센츄리\s*시크릿\s*레어|quarter\s*century\s*secret\s*rare|QC\s*secret\s*rare)/i, rarity: '쿼터 센츄리 시크릿 레어', code: 'QCSE' },
+    { pattern: /(QC\s*시크릿\s*레어|쿼터\s*센추리\s*시크|쿼터\s*센츄리\s*시크|QC\s*쿼터\s*시크릿\s*레어|QC시크릿레어|쿼터\s*시크릿|쿼터\s*센츄리\s*시크릿\s*레어|quarter\s*century\s*secret\s*rare|QC\s*secret\s*rare)/i, rarity: '쿼터 센츄리 시크릿 레어', code: 'QCSE' },
     { pattern: /(홀로그래픽\s*레어|홀로\s*레어|홀로그래픽레어|홀로레어|holographic\s*rare|holographic|holo\s*rare|홀로)/i, rarity: '홀로그래픽 레어', code: 'HR' },
     { pattern: /(프리즈마틱\s*시크릿\s*레어|프리즈매틱\s*시크릿\s*레어|프리즈마틱시크릿레어|프리즈매틱시크릿레어|prismatic\s*secret\s*rare|프리즈마틱\s*시크릿|프리즈매틱\s*시크릿|prismatic|Prismatic)/i, rarity: '프리즈마틱 시크릿 레어', code: 'PSE' },
     { pattern: /(골드\s*시크릿\s*레어|골드시크릿레어|골시크|gold\s*secret\s*rare|골드\s*secret\s*레어)/i, rarity: '골드 시크릿 레어', code: 'GSE' },


### PR DESCRIPTION
온리유희왕의 상품의 경우 가격 앞에 임의의 숫자가 붙는 경우가 있었음
(예를 들이 2000원 상품의 경우 132000원, 9000원 상품의 경우 99000원)
파싱 로직을 강화하여 오류 해결