### PR TITLE
fix: 티씨지샵 상품 제외시 배송비 0원 문제 해결

### DIFF
--- a/src/utils/optimizedPurchase/index.js
+++ b/src/utils/optimizedPurchase/index.js
@@ -325,7 +325,7 @@ function findOptimalPurchaseCombination(cardsList, options = {}) {
 
               // 무료 배송 기준 다시 확인
               const shippingInfo = getShippingInfo(seller);
-              let newShippingCost = sellerData.shippingCost;
+              let newShippingCost;
 
               if (
                 shippingInfo.freeShippingThreshold > 0 &&
@@ -333,6 +333,9 @@ function findOptimalPurchaseCombination(cardsList, options = {}) {
                 newProductCost >= shippingInfo.freeShippingThreshold
               ) {
                 newShippingCost = 0;
+              } else {
+                // 무료배송 조건을 만족하지 못하면 정상 배송비 적용
+                newShippingCost = shippingInfo.shippingFee;
               }
 
               result.cardsOptimalPurchase[seller].shippingCost = newShippingCost;


### PR DESCRIPTION
첫 번째 계산에서 티씨지샵이 무료배송 조건을 만족했을 경우 일부 상품을 제외하고 다시 계산했을 때, 무료배송 조건을 만족하지 못했음에도 티씨지샵 배송비가 그대로 0원이 되는 문제 해결